### PR TITLE
I14 logger parameter

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 import os
 from tempfile import TemporaryDirectory
 from pkg_resources import resource_filename
@@ -6,6 +7,14 @@ from wps_tools.utils import log_handler
 from .common import TestResponse
 from .processes.wps_test_process import TestProcess
 
+logger = logging.getLogger()
+
+formatter = logging.Formatter(
+    "%(asctime)s %(levelname)s: wps-tools: %(message)s", "%Y-%m-%d %H:%M:%S"
+)
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 
 @pytest.mark.parametrize(
     ("message", "process_step"), [("Process completed", "complete")]
@@ -17,7 +26,7 @@ def test_log_handler(message, process_step, log_level, log_file_name, caplog):
     response = TestResponse()
     with TemporaryDirectory() as tmpdir:  # For storing temporary log.txt file
         process.workdir = tmpdir
-        log_handler(process, response, message, process_step, log_level, log_file_name)
+        log_handler(process, response, message, logger, log_level, process_step, log_file_name)
         assert os.path.isfile(os.path.join(tmpdir, log_file_name))
     assert response.message == message
     assert (

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -16,6 +16,7 @@ handler = logging.StreamHandler()
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
+
 @pytest.mark.parametrize(
     ("message", "process_step"), [("Process completed", "complete")]
 )
@@ -26,7 +27,9 @@ def test_log_handler(message, process_step, log_level, log_file_name, caplog):
     response = TestResponse()
     with TemporaryDirectory() as tmpdir:  # For storing temporary log.txt file
         process.workdir = tmpdir
-        log_handler(process, response, message, logger, log_level, process_step, log_file_name)
+        log_handler(
+            process, response, message, logger, log_level, process_step, log_file_name
+        )
         assert os.path.isfile(os.path.join(tmpdir, log_file_name))
     assert response.message == message
     assert (

--- a/wps_tools/utils.py
+++ b/wps_tools/utils.py
@@ -16,16 +16,6 @@ from pathlib import Path
 MAX_OCCURS = 1000
 
 
-logger = logging.getLogger()
-
-formatter = logging.Formatter(
-    "%(asctime)s %(levelname)s: wps-tools: %(message)s", "%Y-%m-%d %H:%M:%S"
-)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-
-
 def is_opendap_url(url):  # From Finch bird
     """
     Check if a provided url is an OpenDAP url.
@@ -116,8 +106,9 @@ def log_handler(
     process,
     response,
     message,
-    process_step=None,
+    logger,
     log_level="INFO",
+    process_step=None,
     log_file_name="log.txt",
 ):
     if process_step:


### PR DESCRIPTION
This PR solves [issue 14](https://github.com/pacificclimate/wps-tools/issues/14), which is to add a `logger` parameter to `log_handler` so that each bird can use its own logging formatter.