### PR TITLE
make_tmp_copy

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,6 +82,7 @@ def test_build_meta_link(outfiles, expected):
     assert all([elem in xml for elem in expected])
 
 
+@pytest.mark.online
 @pytest.mark.parametrize(
     ("http", "expected"),
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,12 +6,14 @@ from wps_tools.utils import (
     get_filepaths,
     collect_output_files,
     build_meta_link,
+    copy_http_content,
 )
 from wps_tools.testing import (
     local_path,
     opendap_path,
 )
 from .processes.wps_test_process import TestProcess
+from netCDF4 import Dataset
 
 NCInput = namedtuple("NCInput", ["url", "file"])
 NCInput.__new__.__defaults__ = ("", "")
@@ -78,3 +80,20 @@ def test_build_meta_link(outfiles, expected):
         outdir=resource_filename(__name__, "data"),
     )
     assert all([elem in xml for elem in expected])
+
+
+@pytest.mark.parametrize(
+    ("http", "opendap"),
+    [
+        (
+            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets/TestData/tiny_hydromodel_gcm_climos.nc",
+            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/tiny_hydromodel_gcm_climos.nc",
+        )
+    ],
+)
+def test_copy_http_content(http, opendap):
+    tmp_copy = copy_http_content(http)
+    print(dir(Dataset(tmp_copy)))
+
+    assert Dataset(tmp_copy).dimensions.keys() == Dataset(opendap).dimensions.keys()
+    assert Dataset(tmp_copy).variables.keys() == Dataset(opendap).variables.keys()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ from wps_tools.testing import (
 )
 from .processes.wps_test_process import TestProcess
 from netCDF4 import Dataset
+from tempfile import NamedTemporaryFile
 
 NCInput = namedtuple("NCInput", ["url", "file"])
 NCInput.__new__.__defaults__ = ("", "")
@@ -95,5 +96,6 @@ def test_build_meta_link(outfiles, expected):
     ],
 )
 def test_copy_http_content(http, expected):
-    tmp_copy = copy_http_content(http)
-    assert dir(Dataset(tmp_copy)) == dir(Dataset(expected))
+    with NamedTemporaryFile(suffix=".nc", prefix="tmp_copy", dir="/tmp", delete=True) as tmp_file:
+        tmp_copy = copy_http_content(http, tmp_file)
+        assert dir(Dataset(tmp_copy)) == dir(Dataset(expected))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,6 +96,8 @@ def test_build_meta_link(outfiles, expected):
     ],
 )
 def test_copy_http_content(http, expected):
-    with NamedTemporaryFile(suffix=".nc", prefix="tmp_copy", dir="/tmp", delete=True) as tmp_file:
+    with NamedTemporaryFile(
+        suffix=".nc", prefix="tmp_copy", dir="/tmp", delete=True
+    ) as tmp_file:
         tmp_copy = copy_http_content(http, tmp_file)
         assert dir(Dataset(tmp_copy)) == dir(Dataset(expected))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -83,17 +83,16 @@ def test_build_meta_link(outfiles, expected):
 
 
 @pytest.mark.parametrize(
-    ("http", "opendap"),
+    ("http", "expected"),
     [
         (
-            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets/TestData/tiny_hydromodel_gcm_climos.nc",
-            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/TestData/tiny_hydromodel_gcm_climos.nc",
+            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/fileServer/datasets/TestData/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc",
+            resource_filename(
+                __name__, "data/gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc"
+            ),
         )
     ],
 )
-def test_copy_http_content(http, opendap):
+def test_copy_http_content(http, expected):
     tmp_copy = copy_http_content(http)
-    print(dir(Dataset(tmp_copy)))
-
-    assert Dataset(tmp_copy).dimensions.keys() == Dataset(opendap).dimensions.keys()
-    assert Dataset(tmp_copy).variables.keys() == Dataset(opendap).variables.keys()
+    assert dir(Dataset(tmp_copy)) == dir(Dataset(expected))

--- a/wps_tools/utils.py
+++ b/wps_tools/utils.py
@@ -1,9 +1,10 @@
 # Processor imports
 from pywps import FORMATS, Process
-from requests import head
+from requests import head, get
 from requests.exceptions import ConnectionError, MissingSchema, InvalidSchema
 from pywps.inout.outputs import MetaLink4, MetaFile
 from pywps.app.exceptions import ProcessError
+from tempfile import NamedTemporaryFile
 
 # Tool import
 from nchelpers import CFDataset
@@ -170,3 +171,23 @@ def log_handler(
     log_file_path = Path(process.workdir) / log_file_name  # From Finch bird
     log_file_path.open("a", encoding="utf8").write(message + "\n")
     response.update_status(message, status_percentage=status_percentage)
+
+
+def make_tmp_copy(output):
+        '''
+        This function is implemented to make a temporary copy of files 
+        provided in http address that are inaccessible to the content
+        without downloading.
+
+        Parameters:
+            output (str): http address of the output of an Osprey process
+        Returs:
+            Path to the copied file in /tmp directory
+        '''
+        output_content = get(output.get()[0]).content
+    
+        tmp_copy = NamedTemporaryFile(
+            suffix=".nc", prefix="tmp_copy", dir="/tmp", delete=False,
+        )
+        tmp_copy.write(output_content)
+        return tmp_copy.name

--- a/wps_tools/utils.py
+++ b/wps_tools/utils.py
@@ -172,19 +172,17 @@ def log_handler(
     response.update_status(message, status_percentage=status_percentage)
 
 
-def copy_http_content(http, tmp_file):
+def copy_http_content(http, file):
     """
         This function is implemented to copy the content of a file passed
-        as an http address to a tmporary file.
+        as an http address to a local file.
 
         Parameters:
             http (str): http address containing the desired content
-            tmp_file (tempfile._TemporaryFileWrapper): path to the 
-                temporary file that the content will be copied to
+            file (file object): path to the 
+                file that the content will be copied to
         Returns:
             Path to the copied file in /tmp directory
         """
-    http_content = get(http).content
-    tmp_file.write(http_content)
-
-    return tmp_file.name
+    file.write(get(http).content)
+    return file.name

--- a/wps_tools/utils.py
+++ b/wps_tools/utils.py
@@ -4,7 +4,6 @@ from requests import head, get
 from requests.exceptions import ConnectionError, MissingSchema, InvalidSchema
 from pywps.inout.outputs import MetaLink4, MetaFile
 from pywps.app.exceptions import ProcessError
-from tempfile import NamedTemporaryFile
 
 # Tool import
 from nchelpers import CFDataset
@@ -173,21 +172,19 @@ def log_handler(
     response.update_status(message, status_percentage=status_percentage)
 
 
-def copy_http_content(http):
+def copy_http_content(http, tmp_file):
     """
-        This function is implemented to make a temporary copy of files 
-        provided in http address that are inaccessible to the content
-        without downloading.
+        This function is implemented to copy the content of a file passed
+        as an http address to a tmporary file.
 
         Parameters:
-            http (str): http address
-        Returs:
+            http (str): http address containing the desired content
+            tmp_file (tempfile._TemporaryFileWrapper): path to the 
+                temporary file that the content will be copied to
+        Returns:
             Path to the copied file in /tmp directory
         """
     http_content = get(http).content
+    tmp_file.write(http_content)
 
-    tmp_copy = NamedTemporaryFile(
-        suffix=".nc", prefix="tmp_copy", dir="/tmp", delete=False,
-    )
-    tmp_copy.write(http_content)
-    return tmp_copy.name
+    return tmp_file.name

--- a/wps_tools/utils.py
+++ b/wps_tools/utils.py
@@ -173,21 +173,21 @@ def log_handler(
     response.update_status(message, status_percentage=status_percentage)
 
 
-def make_tmp_copy(output):
-        '''
+def copy_http_content(http):
+    """
         This function is implemented to make a temporary copy of files 
         provided in http address that are inaccessible to the content
         without downloading.
 
         Parameters:
-            output (str): http address of the output of an Osprey process
+            http (str): http address
         Returs:
             Path to the copied file in /tmp directory
-        '''
-        output_content = get(output.get()[0]).content
-    
-        tmp_copy = NamedTemporaryFile(
-            suffix=".nc", prefix="tmp_copy", dir="/tmp", delete=False,
-        )
-        tmp_copy.write(output_content)
-        return tmp_copy.name
+        """
+    http_content = get(http).content
+
+    tmp_copy = NamedTemporaryFile(
+        suffix=".nc", prefix="tmp_copy", dir="/tmp", delete=False,
+    )
+    tmp_copy.write(http_content)
+    return tmp_copy.name


### PR DESCRIPTION
This PR resolves #18 

`make_tmp_copy` is added to `wps_tools` to copy netCDF content from HTTP URL to `/tmp` directory since `netCDF4.Dataset()` can only read directly from OPeNDAP.