### PR TITLE
Separate online and local tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,23 +23,16 @@ class TestCollectArgs(Process):
     def __init__(self):
         inputs = [
             ComplexInput(
-                "local_file",
-                "Local file",
-                max_occurs=5,
-                abstract="Path to the local input file",
-                supported_formats=[FORMATS.NETCDF],
-            ),
-            ComplexInput(
-                "opendap_url",
-                "OPeNDAP URL",
-                max_occurs=5,
-                abstract="URL to the opendap input file",
-                supported_formats=[FORMATS.DODS],
+                "file",
+                "File",
+                max_occurs=3,
+                abstract="Path to the local or online input file",
+                supported_formats=[FORMATS.NETCDF, FORMATS.DODS],
             ),
             LiteralInput(
                 "argc",
                 "Argument count",
-                max_occurs=5,
+                max_occurs=3,
                 abstract="Number of input arguments",
                 data_type="integer",
             ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,18 +23,25 @@ class TestCollectArgs(Process):
     def __init__(self):
         inputs = [
             ComplexInput(
-                "file",
-                "File",
-                max_occurs=3,
-                abstract="Path to the local or online input file",
+                "file1",
+                "File 1",
+                max_occurs=2,
+                abstract="Path to a local or online input file",
+                supported_formats=[FORMATS.NETCDF, FORMATS.DODS],
+            ),
+            ComplexInput(
+                "file2",
+                "File 2",
+                max_occurs=2,
+                abstract="Path to another local or online input file",
                 supported_formats=[FORMATS.NETCDF, FORMATS.DODS],
             ),
             LiteralInput(
                 "argc",
-                "Argument count",
-                max_occurs=3,
-                abstract="Number of input arguments",
-                data_type="integer",
+                "Argument count dictionary",
+                max_occurs=1,
+                abstract="Number of input arguments for each input",
+                data_type="string",
             ),
         ]
         outputs = [
@@ -59,10 +66,12 @@ class TestCollectArgs(Process):
 
     def _handler(self, request, response):
         collected = collect_args(request, self.workdir)
+        count_dict = eval(request.inputs["argc"][0].data)
+
+        for input_ in collected.keys():
+            assert len(collected[input_]) == count_dict[input_]
+
         collected_argc = sum([len(collected[k]) for k in collected.keys()])
-
-        assert collected_argc == request.inputs["argc"][0].data
-
         response.outputs["collected_argc"].data = collected_argc
         return response
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -9,7 +9,6 @@ from wps_tools.testing import (
 )
 
 nc_file = "gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc"
-remote_directory = "projects/comp_support/daccs/test-data"
 
 
 @pytest.mark.parametrize(("nc_file"), [nc_file])
@@ -30,12 +29,12 @@ def test_url_path(nc_file, url_type, sub_dir):
     if url_type == "opendap":
         assert (
             f"dodsC/datasets/storage/data/projects/comp_support/{sub_dir}"
-            in url_path(os.path.join(remote_directory, nc_file), url_type, sub_dir)
+            in url_path(nc_file, url_type, sub_dir)
         )
     elif url_type == "http":
         assert (
             f"fileServer/datasets/storage/data/projects/comp_support/{sub_dir}"
-            in url_path(os.path.join(remote_directory, nc_file), url_type, sub_dir)
+            in url_path(nc_file, url_type, sub_dir)
         )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,19 +37,31 @@ def test_is_opendap_url(url):
         )  # Ensure function recognizes this is not an opendap file
 
 
+@pytest.mark.parametrize(
+    ("nc_input"),
+    [
+        [NCInput(file=local_path(nc_file))]
+    ],
+)
+def test_get_filepaths_local(nc_input):
+    paths = get_filepaths(nc_input)
+    assert len(paths) == len(nc_input)
+    for path in paths:
+        assert nc_file in path
+
+
 @pytest.mark.online
 @pytest.mark.parametrize(
     ("nc_input"),
     [
-        [NCInput(file=local_path(nc_file))],
         [NCInput(url=url_path(nc_file, "opendap"))],
         [NCInput(file=local_path(nc_file)), NCInput(url=url_path(nc_file, "opendap")),],
     ],
 )
-def test_get_filepaths(nc_input):
-    for input in nc_input:
-        if input.url != "":
-            assert is_opendap_url(input.url)
+def test_get_filepaths_online(nc_input):
+    for nc in nc_input:
+        if nc.url != "":
+            assert is_opendap_url(nc.url)
 
     paths = get_filepaths(nc_input)
     assert len(paths) == len(nc_input)
@@ -119,26 +131,42 @@ def test_url_handler(url_type, url):
         assert is_opendap_url(processed)
 
 
-@pytest.mark.online
 @pytest.mark.parametrize(
-    ("netcdfs", "opendaps", "argc"),
+    ("netcdfs", "argc"),
     [
         (
-            [local_path("tiny_daily_pr.nc"), local_path("tiny_daily_prsn.nc"),],
+            [
+                local_path("tiny_daily_pr.nc"),
+                local_path("tiny_daily_prsn.nc"),
+            ],
+            3,
+        )
+    ],
+)
+def test_collect_args_local(wps_test_collect_args, netcdfs, argc):
+    params = (
+        ";".join([f"file={nc}" for nc in netcdfs])
+        + f";argc={argc};"
+    )
+    run_wps_process(wps_test_collect_args, params)
+
+
+@pytest.mark.online
+@pytest.mark.parametrize(
+    ("netcdfs", "argc"),
+    [
+        (
             [
                 url_path("tiny_daily_pr.nc", "opendap"),
                 url_path("tiny_daily_prsn", "opendap"),
             ],
-            5,
+            3,
         )
     ],
 )
-def test_collect_args(wps_test_collect_args, netcdfs, opendaps, argc):
+def test_collect_args_online(wps_test_collect_args, netcdfs, argc):
     params = (
-        ";".join(
-            [f"local_file={nc}" for nc in netcdfs]
-            + [f"opendap_url=@xlink:href={od}" for od in opendaps]
-        )
+        ";".join([f"file={nc}" for nc in netcdfs])
         + f";argc={argc};"
     )
     run_wps_process(wps_test_collect_args, params)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -128,28 +128,49 @@ def test_url_handler(url_type, url):
         assert is_opendap_url(processed)
 
 
-@pytest.mark.parametrize(
-    ("netcdfs", "argc"),
-    [([local_path("tiny_daily_pr.nc"), local_path("tiny_daily_prsn.nc"),], 3,)],
-)
-def test_collect_args_local(wps_test_collect_args, netcdfs, argc):
-    params = ";".join([f"file={nc}" for nc in netcdfs]) + f";argc={argc};"
+def collect_args_test(wps_test_collect_args, file1, file2, argc):
+    params = (
+        ";".join(
+            [f"file1={nc}" for nc in file1] + [f"file2={file_}" for file_ in file2]
+        )
+        + f";argc={argc};"
+    )
     run_wps_process(wps_test_collect_args, params)
+
+
+@pytest.mark.parametrize(
+    ("file1", "file2", "argc"),
+    [
+        (
+            [local_path("tiny_daily_pr.nc"), local_path("tiny_daily_prsn.nc"),],
+            [local_path("gdd_annual_CanESM2_rcp85_r1i1p1_1951-2100.nc")],
+            {"file1": 2, "file2": 1, "argc": 1},
+        )
+    ],
+)
+def test_collect_args_local(wps_test_collect_args, file1, file2, argc):
+    collect_args_test(wps_test_collect_args, file1, file2, argc)
 
 
 @pytest.mark.online
 @pytest.mark.parametrize(
-    ("netcdfs", "argc"),
+    ("file1", "file2", "argc"),
     [
         (
+            [
+                url_path(
+                    "sample.rvic.prm.COLUMBIA.20180516.nc",
+                    "http",
+                    "climate_explorer_data_prep",
+                )
+            ],
             [
                 url_path("tiny_daily_pr.nc", "opendap"),
                 url_path("tiny_daily_prsn", "opendap"),
             ],
-            3,
+            {"file1": 1, "file2": 2, "argc": 1},
         )
     ],
 )
-def test_collect_args_online(wps_test_collect_args, netcdfs, argc):
-    params = ";".join([f"file={nc}" for nc in netcdfs]) + f";argc={argc};"
-    run_wps_process(wps_test_collect_args, params)
+def test_collect_args_online(wps_test_collect_args, file1, file2, argc):
+    collect_args_test(wps_test_collect_args, file1, file2, argc)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,10 +38,7 @@ def test_is_opendap_url(url):
 
 
 @pytest.mark.parametrize(
-    ("nc_input"),
-    [
-        [NCInput(file=local_path(nc_file))]
-    ],
+    ("nc_input"), [[NCInput(file=local_path(nc_file))]],
 )
 def test_get_filepaths_local(nc_input):
     paths = get_filepaths(nc_input)
@@ -133,21 +130,10 @@ def test_url_handler(url_type, url):
 
 @pytest.mark.parametrize(
     ("netcdfs", "argc"),
-    [
-        (
-            [
-                local_path("tiny_daily_pr.nc"),
-                local_path("tiny_daily_prsn.nc"),
-            ],
-            3,
-        )
-    ],
+    [([local_path("tiny_daily_pr.nc"), local_path("tiny_daily_prsn.nc"),], 3,)],
 )
 def test_collect_args_local(wps_test_collect_args, netcdfs, argc):
-    params = (
-        ";".join([f"file={nc}" for nc in netcdfs])
-        + f";argc={argc};"
-    )
+    params = ";".join([f"file={nc}" for nc in netcdfs]) + f";argc={argc};"
     run_wps_process(wps_test_collect_args, params)
 
 
@@ -165,8 +151,5 @@ def test_collect_args_local(wps_test_collect_args, netcdfs, argc):
     ],
 )
 def test_collect_args_online(wps_test_collect_args, netcdfs, argc):
-    params = (
-        ";".join([f"file={nc}" for nc in netcdfs])
-        + f";argc={argc};"
-    )
+    params = ";".join([f"file={nc}" for nc in netcdfs]) + f";argc={argc};"
     run_wps_process(wps_test_collect_args, params)


### PR DESCRIPTION
I found 2 tests that could be separated into local and online `get_filepaths` and `collect_args`

Test changes with `pytest tests`