### PR TITLE
netcdf 1.5.3 Causeing warnings and Incompatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-pywps==4.2.6
+pywps>=4.2.6
 nchelpers==5.5.7
 rpy2==3.3.6
-netCDF4==1.5.3
+netCDF4>=1.5.4
 beautifulsoup4==4.9.3
 
 # For documentation


### PR DESCRIPTION
- The previous version of netcdf4 is causing warnings that make the notebooks fail in osprey and increasing it causes incompatibility issues with wps-tools
- previous pywps version is incompatible with osprey's