### PR TITLE
Fix output handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,7 @@ class MockResponse:
 
 
 def mock_metalink_respose(*args, **kwargs):
-    outfiles = ["gsl.json", "expected_gsl.rda"]
+    outfiles = ["gsl.json", "tiny_daily_pr.nc"]
     metalink = build_meta_link(
         varname="climo",
         desc="Climatology",

--- a/tests/test_R.py
+++ b/tests/test_R.py
@@ -7,7 +7,9 @@ from wps_tools.R import (
     load_rdata_to_python,
     save_python_to_rdata,
     r_valid_name,
+    get_robjects,
 )
+from wps_tools.testing import local_path
 from pywps.app.exceptions import ProcessError
 
 
@@ -79,3 +81,14 @@ def test_r_valid_name_err(name):
     with pytest.raises(ProcessError) as e:
         r_valid_name(name)
     assert str(vars(e)["_excinfo"][1]) == "Your vector name is not a valid R name"
+
+
+@pytest.mark.parametrize(
+    ("url"), [(local_path("expected_gsl.rda")), (local_path("expected_days_data.rda"))]
+)
+def test_get_robjects(url):
+    objects = get_robjects(url)
+
+    assert len(objects) > 0
+    for ob in objects:
+        assert isinstance(ob, str)

--- a/wps_tools/R.py
+++ b/wps_tools/R.py
@@ -3,6 +3,8 @@ from rpy2 import robjects
 from rpy2.robjects.packages import isinstalled, importr
 from rpy2.rinterface_lib.embedded import RRuntimeError
 from pywps.app.exceptions import ProcessError
+from tempfile import NamedTemporaryFile
+from urllib.request import urlretrieve
 
 
 def get_package(package):
@@ -73,3 +75,22 @@ def r_valid_name(robj_name):
     base = get_package("base")
     if base.make_names(robj_name)[0] != robj_name:
         raise ProcessError(msg="Your vector name is not a valid R name")
+
+
+def get_robjects(url):
+    """
+    Get a list of all the objects stored in an rda file
+
+    Parameters:
+        url (str): file or http url path to a rda file
+
+    Returns:
+        list: a list of the names of objects stored in an rda file
+    """
+    with NamedTemporaryFile(
+        suffix=".rda", prefix="tmp_copy", dir="/tmp", delete=True, mode="wb"
+    ) as r_file:
+        urlretrieve(url, r_file.name)
+        robjs = list(robjects.r(f"load(file='{r_file.name}')"))
+
+    return robjs


### PR DESCRIPTION
The only bird that still uses `output_handling.auto_construct_outputs` is `Thunderbird` because the `getobj=True` argument does not work on metalink output. After the flexible installation update (#45) Thunderbird no longer imports R, but  `Rpy2` was still imported and used in `output_handling`. The R code in this module was redundant anyway, so I just removed most of it. I tested this code with the `Thunderbird` notebooks locally and all the tests pass.