### PR TITLE
Compatibility fixes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,10 +72,16 @@ class TestProcessMultiInput(Process):
         collected = collect_args(request.inputs, self.workdir)
         count_dict = eval(request.inputs["argc"][0].data)
 
+        collected_argc = 0
         for input_ in collected.keys():
-            assert len(collected[input_]) == count_dict[input_]
+            if isinstance(collected[input_], list):
+                collected_argc += len(collected[input_])
+                assert len(collected[input_]) == count_dict[input_]
 
-        collected_argc = sum([len(collected[k]) for k in collected.keys()])
+            else:
+                collected_argc += 1
+                assert type(collected[input_]) != list
+
         response.outputs["collected_argc"].data = collected_argc
         return response
 

--- a/wps_tools/R.py
+++ b/wps_tools/R.py
@@ -5,6 +5,7 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 from pywps.app.exceptions import ProcessError
 from tempfile import NamedTemporaryFile
 from urllib.request import urlretrieve
+from pkg_resources import resource_filename
 
 
 def get_package(package):
@@ -77,6 +78,33 @@ def r_valid_name(robj_name):
         raise ProcessError(msg="Your vector name is not a valid R name")
 
 
+def rda_to_vector(url, vector_name):
+    """
+    Access content from a rda url file as a Rpy2 vector object
+    Parameters:
+        url (str): file or http url path to a rda file
+        vector_name (str): the name the vector was given when it
+            was saved to the rda file
+    Returns:
+        Rpy2 object: Rpy2 representation of the R object "vector_name"
+    """
+    with NamedTemporaryFile(
+        suffix=".rda", prefix="tmp_copy", dir="/tmp", delete=True, mode="wb"
+    ) as r_file:
+        urlretrieve(url, r_file.name)
+        vector = load_rdata_to_python(r_file.name, vector_name)
+
+    return vector
+
+
+def construct_r_out(outputs):
+    r_out = []
+    for value in outputs:
+        if value.endswith(".rda") or value.endswith(".rdata"):
+            r_out.append([rda_to_vector(value, obj) for obj in get_robjects(value)])
+    return r_out
+
+
 def get_robjects(url):
     """
     Get a list of all the objects stored in an rda file
@@ -94,3 +122,16 @@ def get_robjects(url):
         robjs = list(robjects.r(f"load(file='{r_file.name}')"))
 
     return robjs
+
+
+def test_rda_output(url, vector_name, expected_file, expected_vector_name):
+    output_vector = rda_to_vector(url, vector_name)
+    local_path = resource_filename("tests", f"data/{expected_file}")
+    expected_url = f"file://{local_path}"
+    expected_vector = rda_to_vector(expected_url, expected_vector_name)
+
+    for index in range(len(expected_vector)):
+        assert str(output_vector[index]) == str(expected_vector[index])
+
+    # Clear R global env
+    robjects.r("rm(list=ls())")

--- a/wps_tools/R.py
+++ b/wps_tools/R.py
@@ -98,6 +98,7 @@ def rda_to_vector(url, vector_name):
 
 
 def construct_r_out(outputs):
+    """Build list of R outputs"""
     r_out = []
     for value in outputs:
         if value.endswith(".rda") or value.endswith(".rdata"):
@@ -125,6 +126,7 @@ def get_robjects(url):
 
 
 def test_rda_output(url, vector_name, expected_file, expected_vector_name):
+    """Testing method to check rda results"""
     output_vector = rda_to_vector(url, vector_name)
     local_path = resource_filename("tests", f"data/{expected_file}")
     expected_url = f"file://{local_path}"

--- a/wps_tools/io.py
+++ b/wps_tools/io.py
@@ -130,6 +130,11 @@ def collect_args(inputs, workdir):
         info = first.json
         processor = process_literal if info["type"] == "literal" else process_complex
 
-        return [processor(input) for input in multi_input]
+        if info["min_occurs"] > 1 or info["max_occurs"] > 1:
+            return [processor(input) for input in multi_input]
+
+        else:
+            input, = multi_input
+            return processor(input)
 
     return {identifier: process_input(input) for identifier, input in inputs.items()}

--- a/wps_tools/io.py
+++ b/wps_tools/io.py
@@ -156,7 +156,7 @@ def collect_args(inputs, workdir):
             return [processor(input) for input in multi_input]
 
         else:
-            input, = multi_input
+            (input,) = multi_input
             return processor(input)
 
     return {identifier: process_input(input) for identifier, input in inputs.items()}

--- a/wps_tools/io.py
+++ b/wps_tools/io.py
@@ -81,6 +81,28 @@ rda_output = ComplexOutput(
 )
 
 
+def process_inputs_alpha(request_inputs, expected_inputs, workdir):
+    """Process bird inputs and return them in alphabetical order
+
+    This is meant to make it easier to track larger lists of inputs. It will
+    also add in any missing inputs that were not given in the process.
+    """
+    requested = request_inputs.keys()
+    all = [expected.identifier for expected in expected_inputs]
+    missing_inputs = list(set(all) - set(requested))
+
+    collected = collect_args(request_inputs, workdir)
+    for missing_input in missing_inputs:
+        collected[missing_input] = None
+
+    # NOTE: If you want to find out the order of the variables, just uncomment
+    #       these lines.
+    # var_order = [name for name, value in sorted(collected.items())]
+    # print(var_order)
+
+    return [value for name, value in sorted(collected.items())]
+
+
 def collect_args(inputs, workdir):
     """Collects PyWPS input arguments
 
@@ -138,20 +160,3 @@ def collect_args(inputs, workdir):
             return processor(input)
 
     return {identifier: process_input(input) for identifier, input in inputs.items()}
-
-
-def process_inputs(request_inputs, expected_inputs, workdir):
-    requested = request_inputs.keys()
-    all = [expected.identifier for expected in expected_inputs]
-    missing_inputs = list(set(all) - set(requested))
-
-    collected = collect_args(request_inputs, workdir)
-    for missing_input in missing_inputs:
-        collected[missing_input] = None
-
-    # NOTE: If you want to find out the order of the variables, just uncomment
-    #       these lines.
-    var_order = [name for name, value in sorted(collected.items())]
-    print(var_order)
-
-    return [value for name, value in sorted(collected.items())]

--- a/wps_tools/io.py
+++ b/wps_tools/io.py
@@ -138,3 +138,20 @@ def collect_args(inputs, workdir):
             return processor(input)
 
     return {identifier: process_input(input) for identifier, input in inputs.items()}
+
+
+def process_inputs(request_inputs, expected_inputs, workdir):
+    requested = request_inputs.keys()
+    all = [expected.identifier for expected in expected_inputs]
+    missing_inputs = list(set(all) - set(requested))
+
+    collected = collect_args(request_inputs, workdir)
+    for missing_input in missing_inputs:
+        collected[missing_input] = None
+
+    # NOTE: If you want to find out the order of the variables, just uncomment
+    #       these lines.
+    var_order = [name for name, value in sorted(collected.items())]
+    print(var_order)
+
+    return [value for name, value in sorted(collected.items())]

--- a/wps_tools/io.py
+++ b/wps_tools/io.py
@@ -110,7 +110,7 @@ def collect_args(inputs, workdir):
         if "csv" in vars(input)["identifier"]:
             return input.stream
 
-        elif vars(input)["_url"] != None:
+        elif "_url" in vars(input).keys() and vars(input)["_url"] != None:
             return url_handler(workdir, input.url)
 
         elif os.path.isfile(input.file):


### PR DESCRIPTION
All of the birds had issues with the most recent release of `wps-tools`. The changes here are **not** backwards compatible so this would be a major version bump. I have gone ahead and started to implement changes in the birds to integrate this new tooling.

**Changes**
- Added some removed `R` methods (I think at some point we will have to revisit these methods to clean them up)
- Updated `collect_args` to have more specific checks
- Changed `collect_args` to only return a `list` when the inputs require it
- Added method to alphabetize input list (this is mainly for `quail` as it has a million inputs that can become difficult to track)